### PR TITLE
ensure tftp group exists, display output for inner puppet apply

### DIFF
--- a/manifests/bootstrap.pp
+++ b/manifests/bootstrap.pp
@@ -9,6 +9,7 @@ class quartermaster::bootstrap {
     command => '/usr/bin/puppet apply --debug --trace --verbose /etc/puppet/manifests/site.pp',
     require => File['/etc/puppet/manifests/site.pp'],
     timeout => 0,
+    logoutput => true,
   }
 
 }

--- a/manifests/tftpd.pp
+++ b/manifests/tftpd.pp
@@ -24,6 +24,11 @@ class quartermaster::tftpd {
     require  => Package [ 'tftpd-hpa' ],
   }
 
+  group { 'tftp':
+    ensure  => present,
+    before  => File['tftpd_config'],
+  }
+
   file { 'tftpd_config':
     path    => '/etc/default/tftpd-hpa',
     notify  => Service[ 'tftpd-hpa' ],


### PR DESCRIPTION
This pair of changes removes a series of errors caused by the 'tftp' group not being present and also displays the full output from the site apply regardless of errors.  (Previously the output of this inner apply would only display if it exited with an error, which never happened even if parts of the inner apply failed.)
