### PR TITLE
Switch to /8 for primary ip and /16 for dataplane

### DIFF
--- a/templates/scripts/rename.ps1.erb
+++ b/templates/scripts/rename.ps1.erb
@@ -1,35 +1,34 @@
-$conn = @();
+$conn = @(); 
 while ($conn.Count -lt 1) {
-    Write-Output 'Waiting for connection...';
-    Start-Sleep -Seconds 1;
-    $conn = @(Get-WmiObject Win32_NetworkAdapter |
-        Where-Object {$_.NetConnectionStatus -eq 2} |
-        ForEach-Object {$_.GetRelated('Win32_NetworkAdapterConfiguration')} |
+    Write-Output 'Waiting for connection...'; 
+    Start-Sleep -Seconds 1; 
+    $conn = @(Get-WmiObject Win32_NetworkAdapter | 
+        Where-Object {$_.NetConnectionStatus -eq 2} | 
+        ForEach-Object {$_.GetRelated('Win32_NetworkAdapterConfiguration')} | 
         Where-Object {$_.IPAddress -ne $null -and $_.DefaultIPGateway -ne $null -and $_.DNSServerSearchOrder -ne $null});
-    };
-Write-Output $conn;
+    }; 
+Write-Output $conn; 
 Start-Sleep -Seconds 3;
 
 $NewNameSet = $false;
-$conn.IPAddress |
-    Where-Object { $_ -match '([\d]+\.){3}([\d]+)' } |
+$conn.IPAddress | 
+    Where-Object { $_ -match '([\d]+\.){3}([\d]+)' } | 
     ForEach-Object {
-        if ( -not $NewNameSet -and ( $lu = ( nslookup $_ 2>null | findstr /i 'name:' ) ) -ne $null ) {
-            if ( $lu.SubString(5) -match '([^\s.]+)(\.[^\s.]*)*' ) {
-                $NewNameSet = $true; (Get-WmiObject Win32_ComputerSystem).Rename($matches[1]);
-            }
+        if ( -not $NewNameSet -and ( $lu = ( nslookup $_ 2>null | findstr /i 'name:' ) ) -ne $null ) { 
+            if ( $lu.SubString(5) -match '([^\s.]+)(\.[^\s.]*)*' ) { 
+                $NewNameSet = $true; (Get-WmiObject Win32_ComputerSystem).Rename($matches[1]); 
+            } 
         } };
 if (-not $NewNameSet -and $conn.Count -gt 0) {
     (Get-WmiObject Win32_ComputerSystem).Rename($conn[0].MACAddress.Replace(':',''));
 };
 
-$allconn = @(Get-WmiObject Win32_NetworkAdapter |
-            Where-Object {$_.NetConnectionStatus -eq 2} |
-            ForEach-Object {$_.GetRelated('Win32_NetworkAdapterConfiguration')} |
+$allconn = @(Get-WmiObject Win32_NetworkAdapter | 
+            Where-Object {$_.NetConnectionStatus -eq 2} | 
+            ForEach-Object {$_.GetRelated('Win32_NetworkAdapterConfiguration')} | 
             Where-Object {$_.IPAddress -ne $null});
-$ipfilter = $allconn | ForEach-Object {$_.IPAddress} | Where-Object {$_.StartsWith("10.21.")};
+$ipfilter = $allconn | ForEach-Object {$_.IPAddress} | Where-Object { $_ -match '10.([\d]+\.)7.([\d]+)' }
 $dataconn = $allconn | Where-Object {-not $_.IPAddress.contains($ipfilter)};
-
-$octet = @($conn.IPAddress | Where-Object { $_ -match '([\d]+\.){3}([\d]+)' })[0].Split('.')[-1];
-
-$dataconn | ForEach-Object {$_.EnableStatic("10.0.2.$octet","255.255.254.0")};
+$octet1 = @($conn.IPAddress | Where-Object { $_ -match '([\d]+\.){3}([\d]+)' })[0].Split('.')[1]
+$octet2 = @($conn.IPAddress | Where-Object { $_ -match '([\d]+\.){3}([\d]+)' })[0].Split('.')[3]
+$dataconn | ForEach-Object {$_.EnableStatic("10.0.$octet1.$octet2","255.255.0.0")};


### PR DESCRIPTION
Before it was used 10.21.7.0/24 hardcoded for primary IP & 10.0.2.0/23 (data) and it was not scalable. The updated script uses 10.0.0.0/8 with pattern as 10.<octet1>.1.<octet2> for primary IP and dataplane switch to 10.0.0.0/16 with pattern 10.0.<rack>.<ip>
